### PR TITLE
Ensure tasks can be invoked multiple times

### DIFF
--- a/tasks.rb
+++ b/tasks.rb
@@ -18,6 +18,11 @@ module TaskExampleGroup
     let(:task_name) { self.class.top_level_description.sub(/\Arake /, '') }
     let(:tasks) { Rake::Task }
     subject(:task) { tasks[task_name] }
+    
+    after(:each) do
+      task.all_prerequisite_tasks.each { |prerequisite| tasks[prerequisite].reenable }
+      task.reenable
+    end
   end
 end
 


### PR DESCRIPTION
Without this logic in place, I'm not able to have multiple expectations on a single rake test which has many pre-requisite tasks:

```ruby
require 'rails_helper'

describe 'rake foo:bar', type: :task do
  it { expect { task.invoke }.not_to raise_error }
  it { expect { task.invoke }.to change { Foo.count }.from(0).to(1) }
  it { expect { task.invoke }.to change { Bar.count }.from(0).to(3) }
end
```